### PR TITLE
New feature : load plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,19 @@ GruntfileEditor.prototype.insertConfig = function (name, config) {
 };
 
 /**
+ * Load a Grunt plugin
+ * @param {String}               pluginName - name of the plugin to load (ex: 'grunt-contrib-uglify')
+ * @return {this}
+ */
+
+GruntfileEditor.prototype.loadNpmTasks = function (pluginName) {
+  this.gruntfile.assignment('module.exports').value().body.prepend(
+    'grunt.loadNpmTasks("' + pluginName + '");'
+  );
+  return this;
+};
+
+/**
  * Register a task inside a named task group
  * @param {String}               name  - Task group name
  * @param {String|Array[String]} tasks - Tasks name to insert in the group

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,19 @@ describe('GruntfileEditor', function () {
     });
   });
 
+  describe('#loadNpmTask()', function () {
+
+    it('insert task plugin load if not existing', function () {
+      this.editor.loadNpmTasks('grunt-contrib-concat');
+      assert(this.editor.gruntfile.toString().indexOf('grunt.loadNpmTasks(\'grunt-contrib-concat\')') >= 0);
+    });
+
+    it('is chainable', function () {
+      assert.equal(this.editor.loadNpmTasks('grunt-contrib-uglify'), this.editor);
+    });
+
+  });
+
   describe('#registerTask()', function () {
     beforeEach(function () {
       this.editor.registerTask('exist', 'bar');


### PR DESCRIPTION
I've implemented a solution for https://github.com/SBoudrias/gruntfile-editor/issues/3.

I've created a method to load a Grunt plugin in a Gruntfile.js

USAGE : 

```
generator.gruntfile.loadNpmTasks('grunt-contrib-csslint');
```
