### PR TITLE
fix updating variable in #insertConfig()

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,12 @@ var GruntfileEditor = module.exports = function (gruntfileContent) {
 GruntfileEditor.prototype.insertConfig = function (name, config) {
   assert(_.isString(name), 'You must provide a task name');
   assert(_.isString(config), 'You must provide a task configuration body as String');
-  this.gruntfile.callExpression('grunt.initConfig').arguments.at(0)
-    .key(name).value(config);
+  var expression = this.gruntfile.callExpression('grunt.initConfig').arguments
+    .at(0).key(name);
+  try {
+    expression.value(config);
+  }
+  catch (e) {}
   return this;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,18 @@ describe('GruntfileEditor', function () {
       assert(this.editor.gruntfile.toString().indexOf('compass: { yeo: \'man\' }') >= 0);
     });
 
+    it('inserts a variable as the value', function () {
+      this.editor.insertConfig('conf', 'config');
+      assert(this.editor.gruntfile.toString().indexOf('conf: config') >= 0);
+    });
+
+    it('updates a variable as the value', function () {
+      this.editor.insertConfig('conf', 'config');
+      this.editor.insertConfig('conf', 'config2');
+      assert(this.editor.gruntfile.toString().indexOf('conf: config') >= 0);
+      assert(this.editor.gruntfile.toString().indexOf('conf: config2') < 0);
+    });
+
     it('is chainable', function () {
       assert.equal(this.editor.insertConfig('compass', '{}'), this.editor);
     });


### PR DESCRIPTION
When trying to update a config block that was a variable reference, an error was being thrown:

```
/Users/eddie/Dropbox/Sites/OSS/yeoman/generator/node_modules/gruntfile-editor/index.js:33
    .key(name).value(config);
               ^
TypeError: Object #<Object> has no method 'value'
    at GruntfileEditor.insertConfig (/Users/eddie/Dropbox/Sites/OSS/yeoman/generator/node_modules/gruntfile-editor/index.js:33:16)
    at module.exports (/Users/eddie/Dropbox/Sites/OSS/yeoman/generator-angular/helpers/gruntfile.js:16:18)
    at module.exports.yeoman.generators.Base.extend.writing.build (/Users/eddie/Dropbox/Sites/OSS/yeoman/generator-angular/generators/app/index.js:255:17)
    at /Users/eddie/Dropbox/Sites/OSS/yeoman/generator/lib/base.js:387:14
    at processImmediate [as _immediateCallback] (timers.js:336:15)
```
