### PR TITLE
Update to the expanding testing from elsewhere

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,9 @@
+var assert = require('assert');
+var noDef = ' is not defined';
+
 module.exports = {
   str: function () {
+    assert(this.editor.gruntfile.toString, 'gruntfile.toString' + noDef);
     return this.editor.gruntfile.toString();
   },
 
@@ -8,14 +12,22 @@ module.exports = {
   },
 
   insertConfig: function (name, body) {
+    assert(this.editor.insertConfig, 'insertConfig' + noDef);
     return this.editor.insertConfig.bind(this.editor, name, body);
   },
 
   insertVariable: function (name, value) {
+    assert(this.editor.insertVariable, 'insertVariable' + noDef);
     return this.editor.insertVariable.bind(this.editor, name, value);
   },
 
   load: function (plugin) {
+    assert(this.editor.loadNpmTasks, 'loadNpmTasks' + noDef);
     return this.editor.loadNpmTasks.bind(this.editor, plugin);
-  }
+  },
+
+  registerTask: function (group, tasks, multi) {
+    assert(this.editor.registerTask, 'registerTask' + noDef);
+    return this.editor.registerTask.bind(this.editor, group, tasks, multi);
+  },
 };

--- a/test/registertask.js
+++ b/test/registertask.js
@@ -1,0 +1,238 @@
+/*globals describe, it, beforeEach, afterEach */
+'use strict';
+
+var assert = require('assert');
+var GruntfileEditor = require('..');
+var helper = require('./helpers');
+
+describe('#registerTask()', function () {
+  beforeEach(function () {
+    this.editor = new GruntfileEditor();
+    this.register = helper.registerTask;
+    this.str = helper.str;
+  });
+
+  it('is chainable', function () {
+    assert.equal(this.editor.registerTask('build', 'foo'), this.editor);
+  });
+
+  describe('requires a name', function () {
+    var msg = /You must provide a task group name/;
+
+    it('requires a String name', function () {
+      assert.throws(this.register(), msg);
+      assert.throws(this.register(''), msg);
+      assert.throws(this.register(' '), msg);
+      assert.throws(this.register({}), msg);
+      assert.throws(this.register(42), msg);
+      assert.throws(this.register(false), msg);
+      assert.throws(this.register(true), msg);
+      assert.throws(this.register(0), msg);
+      assert.throws(this.register(-1), msg);
+      assert.throws(this.register([ 'an', 'array' ]), msg);
+    });
+  });
+
+  describe('require task(s)', function () {
+    var msg = /You must provide a task or an array of tasks/;
+
+    it('as a String', function () {
+      assert(this.register('name', 'task'));
+      assert(this.register('name', '  task  '));
+      assert.throws(this.register('name'), msg);
+      assert.throws(this.register('name', ''), msg);
+      assert.throws(this.register('name', ' '), msg);
+    });
+
+    it('as an Array', function () {
+      assert(this.register('name', ['task']));
+      assert(this.register('name', ['task', 'task2']));
+      assert.throws(this.register('name'), msg);
+      assert.throws(this.register('name', []), msg);
+    });
+
+    describe('does not yet accept:', function () {
+      it('an object', function () {
+        assert.throws(this.register('name', {}), msg);
+      });
+
+      it('an integer', function () {
+        assert.throws(this.register('name', 4), msg);
+      });
+
+      it('a boolean', function () {
+        assert.throws(this.register('name', false), msg);
+        assert.throws(this.register('name', true), msg);
+      });
+    });
+  });
+
+  describe('optional options', function () {
+    var msg = /If you provide options, they must be as an Object/;
+
+    it('as an object', function () {
+      assert(this.register('name', '  task  '));
+      assert(this.register('name', 'task', {}));
+      assert(this.register('name', 'task', null), msg);
+      assert(this.register('name', 'task', false), msg);
+      assert(this.register('name', 'task', { duplicates: true }), msg);
+      assert.throws(this.register('name', 'task', 'options'), msg);
+      assert.throws(this.register('name', 'task', ['options']), msg);
+      assert.throws(this.register('name', 'task', /regex/), msg);
+      assert.throws(this.register('name', 'task', new Number(1)), msg);
+      assert.throws(this.register('name', 'task', function () {
+        return true;
+      }), msg);
+    });
+  });
+
+  describe('insert into', function () {
+    var gf;
+
+    beforeEach(function () {
+      gf = 'grunt.registerTask(\'deploy\', [' +
+        '\n        \'foo\',' +
+        '\n        \'bar\',' +
+        '\n        \'baz\'';
+    });
+
+    describe('a new group', function () {
+      it('a single task', function () {
+        gf = 'grunt.registerTask(\'deploy\', [\'foo\'])';
+        assert(this.str().indexOf(gf) < 0);
+        this.editor.registerTask('deploy', 'foo');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('a single task with a target', function () {
+        gf = 'grunt.registerTask(\'deploy\', [\'foo:bar\'])';
+        assert(this.str().indexOf(gf) < 0);
+        this.editor.registerTask('deploy', 'foo:bar');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('an array of tasks', function () {
+        gf +=  '\n    ])';
+        assert(this.str().indexOf(gf) < 0);
+        this.editor.registerTask('deploy', ['foo', 'bar', 'baz']);
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('a csv list of tasks', function () {
+        gf +=  '\n    ])';
+        assert(this.str().indexOf(gf) < 0);
+        this.editor.registerTask('deploy', 'foo,bar,baz');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('a csv list (with spaces) of tasks', function () {
+        gf += ',\n        \'cat\'\n    ])';
+        assert(this.str().indexOf(gf) < 0);
+        this.editor.registerTask('deploy', 'foo, bar,   baz,      cat');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+    });
+
+    describe('an existing group with one item', function () {
+      beforeEach(function () {
+        gf = 'grunt.registerTask(\'exist\', [\n        \'bar\',';
+        this.editor.registerTask('exist', 'bar');
+      });
+
+      it('a single task', function () {
+        this.editor.registerTask('exist', 'foo');
+        assert(this.str().indexOf(gf + '\n        \'foo\'\n    ])') >= 0);
+      });
+
+      it('a single task with a target', function () {
+        this.editor.registerTask('exist', 'foo:bar');
+        assert(this.str().indexOf(gf + '\n        \'foo:bar\'\n    ])') >= 0);
+      });
+
+      it('an array of tasks', function () {
+        gf += '\n        \'foo\',\n        \'baz\'\n    ])';
+        this.editor.registerTask('exist', ['foo', 'baz']);
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('not one task multiple times', function () {
+        gf = 'grunt.registerTask(\'exist\', [\'bar\'])';
+        this.editor.registerTask('exist', 'bar');
+        this.editor.registerTask('exist', 'bar');
+        this.editor.registerTask('exist', 'bar');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('one task multiple times', function () {
+        gf += '\n        \'bar\',\n        \'bar\'\n    ])';
+        this.editor.registerTask('exist', 'bar', { duplicates: true });
+        this.editor.registerTask('exist', 'bar', { duplicates: true });
+        assert(this.str().indexOf(gf) >= 0);
+      });
+    });
+
+    describe('an existing group with many items', function () {
+      beforeEach(function () {
+        this.editor.registerTask('deploy', 'foo,bar,baz');
+      });
+
+      it('a single task', function () {
+        gf += ',\n        \'cat\'\n    ])';
+        this.editor.registerTask('deploy', 'cat');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('a single task with a target', function () {
+        gf += ',\n        \'foo:bar\'\n    ])';
+        this.editor.registerTask('deploy', 'foo:bar');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('an array of tasks', function () {
+        gf += ',\n        \'cat\',' +
+          '\n        \'bak\'' +
+          '\n    ])';
+        this.editor.registerTask('deploy', ['cat', 'bak']);
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('not one task multiple times', function () {
+        gf += '\n    ])';
+        this.editor.registerTask('deploy', 'foo');
+        this.editor.registerTask('deploy', 'foo');
+        this.editor.registerTask('deploy', 'bar');
+        this.editor.registerTask('deploy', 'bar');
+        this.editor.registerTask('deploy', 'baz');
+        this.editor.registerTask('deploy', 'baz');
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('one task multiple times', function () {
+        gf += ',\n        \'bar\',' +
+          '\n        \'bar\'' +
+          '\n    ])';
+        this.editor.registerTask('deploy', 'bar', { duplicates: true });
+        this.editor.registerTask('deploy', 'bar', { duplicates: true });
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('not an array of tasks multiple times', function () {
+        this.editor.registerTask('deploy', ['foo', 'bar']);
+        this.editor.registerTask('deploy', ['foo', 'bar']);
+        this.editor.registerTask('deploy', ['foo', 'bar']);
+        assert(this.str().indexOf(gf) >= 0);
+      });
+
+      it('an array of tasks multiple times', function () {
+        gf += ',\n        \'foo\',' +
+          '\n        \'bar\',' +
+          '\n        \'baz\'' +
+          '\n    ])';
+        this.editor.registerTask('deploy', ['foo', 'bar', 'baz'], {
+          duplicates: true
+        });
+        assert(this.str().indexOf(gf) >= 0);
+      });
+    })
+  });
+});


### PR DESCRIPTION
- Fixes #5
  - Do not add the same item multiple times
  - Do not add the tasks in an array multiple times
  - Adds a flag to insert an item or the items in an array multiple times

BREAKING CHANGE: This includes a breaking change by requiring the multiple flag to be set to allow multiple items. I believe this is the intention most people would use as running the same grunt task multiple times is rarely done but having the registerTask called multiple times as a precaution to make sure it is there is done quite often. I don't think people would expect that to insert it multiple times.
